### PR TITLE
Error arreglado. Faltaba la comparación atributo por atributo

### DIFF
--- a/src/test/java/com/library/feature/user/domain/GetUsersUseCaseTest.java
+++ b/src/test/java/com/library/feature/user/domain/GetUsersUseCaseTest.java
@@ -32,24 +32,34 @@ class GetUsersUseCaseTest {
     }
 
     @Test
-    public void cuandoObtengoLaListaYTieneModelosUser(){
+    public void cuandoObtengoLaListaYTieneModelosUser() {
         //Given: Declaración de variables
         List<User> usersExpected = new ArrayList<>();
-        usersExpected.add(new  User("1", "Gabriel", "Polo", "12360138M", "10/05/2014"));
+        usersExpected.add(new User("1", "Gabriel", "Polo", "12360138M", "10/05/2014"));
         usersExpected.add(new User("2", "Marcos", "Murial", "14462902E", "11/11/2021"));
         Mockito.when(userRepository.getUsers()).thenReturn(usersExpected);
 
 
         //When
-        List<User> userReceived = getUsersUseCase.execute();
+        List<User> usersReceived = getUsersUseCase.execute();
 
         //Then
-        assertEquals(usersExpected.size(), usersExpected.size());
+        assertEquals(usersReceived.size(), usersExpected.size());
+        for (int i = 0; i < usersExpected.size(); i++) {
+            User expected = usersExpected.get(i);
+            User received = usersReceived.get(i);
+
+            Assertions.assertEquals(expected.id,received.id);
+            Assertions.assertEquals(expected.name,received.name);
+            Assertions.assertEquals(expected.surname,received.surname);
+            Assertions.assertEquals(expected.dni,received.dni);
+            Assertions.assertEquals(expected.dateInscription,received.dateInscription);
+        }
 
     }
 
     @Test
-    public void cuandoObtengoLaListaYEsNullEstaVacia(){
+    public void cuandoObtengoLaListaYEsNullEstaVacia() {
         //Given: Declaración de variables
         List<User> usersExpectedEmpty = new ArrayList<>();
         Mockito.when(userRepository.getUsers()).thenReturn(usersExpectedEmpty);
@@ -60,6 +70,6 @@ class GetUsersUseCaseTest {
 
 
         //Then
-        assertEquals(0,usersReceivedEmpty.size());
+        assertEquals(0, usersReceivedEmpty.size());
     }
 }


### PR DESCRIPTION
# Breve descripción del ticket asociado
Faltaba la comparación atributo a atributo de cada uno de los objeto `User` que forman la lista de `Users`

## 👩‍💻Resumen de los cambios introducidos
El cambio está en el método `cuandoObtengoLaListaYTieneModelosUser` del test

## 📸 Screenshot o Video
![image](https://github.com/Fouad-Trabajo/digital-library/assets/146753676/da2eefb4-e064-4b78-9e22-ceaf14bd6728)
